### PR TITLE
Remove unnecessary double-dash in docker run invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ steps:
   - label: integration-tests
     command: ./integration-tests.sh
     plugins:
-      - improbable-eng/docker-service#v0.2.0:
+      - improbable-eng/docker-service#v0.3.0:
           container: postgres:12.6
           flags:
             - --env=POSTGRES_DB=postgres
@@ -41,7 +41,7 @@ steps:
   - label: my-step
     command: ./step-script.sh
     plugins:
-      - improbable-eng/docker-service#v0.2.0:
+      - improbable-eng/docker-service#v0.3.0:
           container: a-container:1.2.3
           cmd: "my-command --flag=value arg1 arg1"
 ```
@@ -65,7 +65,7 @@ by using the [Docker Buildkite plugin] with its `network` option.
 steps:
   - label: my-dockerised-step
     plugins:
-      - improbable-eng/docker-service#v0.2.0:
+      - improbable-eng/docker-service#v0.3.0:
           container: postgres:12.6
           network: "postgres"
           flags:

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -41,7 +41,7 @@ unset parse_flags
 docker_cmd="${docker_cmd} ${BUILDKITE_PLUGIN_DOCKER_SERVICE_CONTAINER}"
 
 if [[ -n "${BUILDKITE_PLUGIN_DOCKER_SERVICE_CMD:-}" ]]; then
-  docker_cmd="${docker_cmd} -- ${BUILDKITE_PLUGIN_DOCKER_SERVICE_CMD}"
+  docker_cmd="${docker_cmd} ${BUILDKITE_PLUGIN_DOCKER_SERVICE_CMD}"
 fi
 
 DOCKER_SERVICE_CONTAINER_ID="$(eval "${docker_cmd}")"


### PR DESCRIPTION
`docker run` does not use the standard double-dash (`--`) syntax to separate args passed to the wrapper (i.e `docker run`) and args passed to the wrappee (i.e command invoked inside the container).
