### PR TITLE
feat: make lockfile directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ steps:
 
 ## Configuration
 
-| Option    | Required | Type            | Description                                     | Default          |
-| --------- | :------: | --------------- | ----------------------------------------------- | ---------------- |
-| container | **Yes**  | string          | Container image to run                          | n.a              |
-| cmd       |    No    | string          | Command to run in the container                 | `<empty string>` |
-| flags     |    No    | list of strings | List of flags for 'docker run'                  | `<empty list>`   |
-| network   |    No    | string          | Docker network to which to attach the container | `host`           |
-
+| Option         | Required | Type            | Description                                     | Default          |
+| -------------- | :------: | --------------- | ----------------------------------------------- | ---------------- |
+| container      | **Yes**  | string          | Container image to run                          | n.a              |
+| cmd            |    No    | string          | Command to run in the container                 | `<empty string>` |
+| flags          |    No    | list of strings | List of flags for 'docker run'                  | `<empty list>`   |
+| network        |    No    | string          | Docker network to which to attach the container | `host`           |
+| lockfile-dir   |    No    | string          | Directory in which to create the lock file      | `/var/lock`      |
 ## Environment variables
 
 The plugin will set the following environment variables which will be accessible to your build:

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -19,7 +19,7 @@ if [[ "${BUILDKITE_PLUGIN_DOCKER_SERVICE_NETWORK:-host}" != "host" ]]; then
     if [[ "$(docker network ls --filter="name=${BUILDKITE_PLUGIN_DOCKER_SERVICE_NETWORK}" --format="{{.Name}}")" != "${BUILDKITE_PLUGIN_DOCKER_SERVICE_NETWORK}" ]]; then
       docker network create --driver=bridge "${BUILDKITE_PLUGIN_DOCKER_SERVICE_NETWORK}"
     fi
-  ) 9>/var/lock/docker-service-buildkite-plugin.lock
+  ) 9>"${BUILDKITE_PLUGIN_DOCKER_SERVICE_LOCKFILE_DIR:-/var/lock}/docker-service-buildkite-plugin.lock"
 fi
 
 docker_cmd="${docker_cmd} --network=${BUILDKITE_PLUGIN_DOCKER_SERVICE_NETWORK:-host}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -20,3 +20,6 @@ configuration:
     network:
       description: "Docker network to which to attach the container."
       type: string
+    lockfile-dir:
+      description: "Directory in which to create the lock file"
+      type: string


### PR DESCRIPTION
##  Rationale

The `buildkite-agent` user on agents provisioned using the standard [elastic agent stack](https://buildkite.com/docs/tutorials/elastic-ci-stack-aws) doesn't have write permissions to `/var/lock`

## Changes

* introduced the `lockfile-dir` parameter which allows to configure where the lock file will be created

## Verification

Tested in our environment by setting the `lockfile-dir` parameter to `/tmp`
